### PR TITLE
improve: add jsx fragment factory

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "jsx": "react",
-    "jsxFactory": "h"
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "h.Fragment"
   },
   "include": [
     "src"


### PR DESCRIPTION
Without the fragment factory you can't use the `<> ... </>` as a fragment shorthand. If it's set to `Fragment` instead of `h.Fragment`, you'd have to manually import `Fragment` or otherwise you'd get a "Cannot find name 'Fragment'." error.  With `h.Fragment`, `<> ... </>` just works.

Thanks @WickyNilliams for the hint!